### PR TITLE
Feature/helios

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # For building the DCAP validator
-FROM golang:1.22 as go-tdx-builder
+FROM golang:1.22 AS go-tdx-builder
 WORKDIR /root/
 RUN git clone https://github.com/Ruteri/dummy-tdx-dcap
 WORKDIR /root/dummy-tdx-dcap
@@ -21,6 +21,9 @@ RUN tar -xzf ./foundry_nightly_linux_amd64.tar.gz -C /usr/local/bin
 
 # Install the TDX checker
 COPY --from=go-tdx-builder /root/dummy-tdx-dcap/dcap-verifier /usr/local/bin
+
+# Install helios
+RUN curl -L 'https://github.com/a16z/helios/releases/download/0.7.0/helios_linux_amd64.tar.gz' | tar -xzC .
 
 # Python
 WORKDIR /workdir

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,18 @@ services:
     volumes:
       - /var/run/tappd.sock:/var/run/tappd.sock
       - /tmp/tapp-ramdisk:/tmp/tapp-ramdisk
-    ports:
-      - "4001:4001"
     environment:
       - SECURE_FILE=/tmp/tapp-ramdisk/private.env
       - CONTRACT=0x2c5032c6b1ec3d13acc81758d83e0b4478e153ff
       - ETH_RPC_PREFIX=https://base-mainnet.g.alchemy.com/v2/
       - CHAIN_ID=8453
+    networks:
+      my_network:
+        ipv4_address: 172.16.238.10
 
+networks:
+  my_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.16.238.0/24

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - SECURE_FILE=/tmp/tapp-ramdisk/private.env
       - CONTRACT=0x2c5032c6b1ec3d13acc81758d83e0b4478e153ff
-      - ETH_RPC_PREFIX=https://base-mainnet.g.alchemy.com/v2/
+      - ETH_RPC_BASE=base-mainnet.quiknode.pro
       - CHAIN_ID=8453
     networks:
       my_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,7 @@ services:
     environment:
       - SECURE_FILE=/tmp/tapp-ramdisk/private.env
       - CONTRACT=0x2c5032c6b1ec3d13acc81758d83e0b4478e153ff
-      - ETH_RPC_BASE=base-mainnet.quiknode.pro
-      - CHAIN_ID=8453
+      - HELIOS_PARAM=opstack --network base
     networks:
       my_network:
         ipv4_address: 172.16.238.10

--- a/replicatoor.py
+++ b/replicatoor.py
@@ -18,17 +18,16 @@ from urllib.parse import urlparse
 ETH_RPC_URL = None
 
 # Trusted values read from image
-ETH_RPC_BASE = os.environ['ETH_RPC_BASE']
+HELIOS_PARAM = os.environ['HELIOS_PARAM']  # e.g., opstack --network base
 CONTRACT    = os.environ['CONTRACT']
-CHAIN_ID    = os.environ['CHAIN_ID']
 SECURE_FILE = os.environ['SECURE_FILE']
 
-# Helios proc
+# Helios light client running as a subprocess
 helios_proc = None
 def run_lightclient():
     global helios_proc
     assert helios_proc is None
-    helios_proc = subprocess.Popen(f"/root/helios opstack --network base --execution-rpc {ETH_RPC_URL}", stdin=None, stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=True, text=True)
+    helios_proc = subprocess.Popen(f"/root/helios {HELIOS_PARAM} --execution-rpc {ETH_RPC_URL}", stdin=None, stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=True, text=True)
 
 # Here's all the key state
 global_state = dict(
@@ -141,7 +140,6 @@ def configure():
     print('Received configuration parameters:', config, file=sys.stderr)
     global ETH_RPC_URL
     os.environ['ETH_RPC_URL'] = ETH_RPC_URL = config['ETH_RPC_URL']
-    assert urlparse(ETH_RPC_URL).netloc.endswith(ETH_RPC_BASE)
     run_lightclient()
     return jsonify({"status": "success", "config": config}), 200
 

--- a/test.sh
+++ b/test.sh
@@ -3,8 +3,8 @@ set -x
 set -e
 
 # Configure to the IP address of the container
-GUEST=172.25.0.2:4001
-GUEST_tO=localhost:4001
+#GUEST=172.16.238.10:4001
+GUEST=localhost:14001
 
 # Configure the API keys
 curl -X POST -H "Content-Type: text/plain" --data-binary @host.env http://$GUEST/configure

--- a/test.sh
+++ b/test.sh
@@ -3,15 +3,15 @@ set -x
 set -e
 
 # Configure to the IP address of the container
-#GUEST=172.16.238.10:4001
-GUEST=localhost:14001
+GUEST=172.16.238.10:4001
+#GUEST=localhost:14001
 
 # Configure the API keys
 curl -X POST -H "Content-Type: text/plain" --data-binary @host.env http://$GUEST/configure
-curl http://$GUEST/status
+#curl http://$GUEST/status
 
 # Write some secrets
-sudo cp private.env /tmp/tapp-ramdisk/private.env
+cp private.env /tmp/tapp-ramdisk/private.env
 
 # Request the key
 curl -s -X POST http://$GUEST/requestKey > request.out
@@ -23,4 +23,4 @@ curl -s -X POST -d "pubk=$PUBK" -d "quote=$QUOTE"  http://$GUEST/onboard > onboa
 
 # Post the encrypted state file
 curl -X POST -H "Content-Type: text/plain" --data-binary @onboard.out http://$GUEST/receiveKey
-curl http://$GUEST/status
+#curl http://$GUEST/status


### PR DESCRIPTION
Address #2 by adding support for Helios light client.

This is tested on the base mainnet using the *free trial* endpoint of quicknode RPC to provide `eth_getProofs`
https://www.quicknode.com/docs/ethereum/eth_getProof

Since we are no longer having to trust the RPC itself, we no longer need to constrain it